### PR TITLE
added default delay to fix missing delay error

### DIFF
--- a/gamemodes/terrortown/entities/entities/soda_shootup/shared.lua
+++ b/gamemodes/terrortown/entities/entities/soda_shootup/shared.lua
@@ -45,6 +45,10 @@ if SERVER then
 
 	local function ApplyWeaponSpeed(wep)
 		if (wep.Kind == WEAPON_HEAVY or wep.Kind == WEAPON_PISTOL) then
+			if not wep.Primary.Delay then
+				wep.Primary.Delay = 0.15
+			end
+
 			local delay = math.Round(wep.Primary.Delay / GetConVar("ttt_soda_shootup"):GetFloat(), 3)
 
 			wep.Delay_old = wep.Primary.Delay


### PR DESCRIPTION
This PR fixes #8 by adding a default delay if the delay is missing.
The default delay of 0.15 was used because this is also used in the weapon_tttbase.
For example a handful of weapons use a custom base and don't use SWEP.Primary.Delay.
Therefore an error appears if you are using the shootup soda.
This also fixes another error if you try to consume the shootup soda:
```
[ttt2-super-soda-master] addons/ttt2-super-soda-master/gamemodes/terrortown/entities/entities/soda_shootup/shared.lua:48: attempt to perform arithmetic on field 'Delay' (a nil value)
  1. ApplyWeaponSpeed - addons/ttt2-super-soda-master/gamemodes/terrortown/entities/entities/soda_shootup/shared.lua:48
   2. ConsumeSoda - addons/ttt2-super-soda-master/gamemodes/terrortown/entities/entities/soda_shootup/shared.lua:64
    3. PickupSoda - addons/ttt2-super-soda-master/lua/terrortown/autorun/shared/sh_supersoda_handler.lua:93
     4. fn - addons/ttt2-super-soda-master/lua/terrortown/autorun/shared/sh_supersoda_handler.lua:113
      5. unknown - lua/ulib/shared/hook.lua:109
```